### PR TITLE
added LD_LIBRARY_PATH to odin.nix for raylib functionality

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -90,6 +90,7 @@ let
       hash = "sha256-RNSFbdifRkokv1JIjABWfGEXtb3kSg1Ps2Pv68YzyDA=";
     };
     llvmPackages = prev.llvmPackages_18;
+    pkgs = prev.pkgs
   };
 
   ols = prev.callPackage ./ols.nix { odin = odin-latest; };

--- a/default.nix
+++ b/default.nix
@@ -90,7 +90,7 @@ let
       hash = "sha256-RNSFbdifRkokv1JIjABWfGEXtb3kSg1Ps2Pv68YzyDA=";
     };
     llvmPackages = prev.llvmPackages_18;
-    pkgs = prev.pkgs
+    pkgs = prev.pkgs;
   };
 
   ols = prev.callPackage ./ols.nix { odin = odin-latest; };

--- a/odin.nix
+++ b/odin.nix
@@ -39,9 +39,9 @@ in stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
-      --prefix LD_LIBRARY_PATH : ${
-          lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL])
-        } \ 
+      #--prefix LD_LIBRARY_PATH : ${
+      #    lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL])
+      #  } \ 
       --set-default ODIN_ROOT $out/share
 
     runHook postInstall

--- a/odin.nix
+++ b/odin.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
       --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL alsa-lib ])
+        lib.makeLibraryPath (with pkgs; [ libGL alsa-lib xorg.libX11 xorg.libXrandr xorg.libXi xorg.libXcursor xorg.libXinerama])
       } \
       --set-default ODIN_ROOT $out/share
 

--- a/odin.nix
+++ b/odin.nix
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
-      --prefix LD_LIBRARY_PATH : $ {
+      --prefix LD_LIBRARY_PATH : ${
           lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL])
         } \ 
       --set-default ODIN_ROOT $out/share

--- a/odin.nix
+++ b/odin.nix
@@ -39,6 +39,9 @@ in stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [ pkgs.xorg.libX11 pkgs.libGL ]
+      } \
       --set-default ODIN_ROOT $out/share
 
     runHook postInstall

--- a/odin.nix
+++ b/odin.nix
@@ -39,9 +39,6 @@ in stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
-      #--prefix LD_LIBRARY_PATH : ${
-      #    lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL])
-      #  } \ 
       --set-default ODIN_ROOT $out/share
 
     runHook postInstall

--- a/odin.nix
+++ b/odin.nix
@@ -1,4 +1,4 @@
-{ lib, llvmPackages, makeBinaryWrapper, libiconv, which, version, src, }:
+{ lib, llvmPackages, makeBinaryWrapper, libiconv, which, version, src, pkgs}:
 let inherit (llvmPackages) stdenv;
 in stdenv.mkDerivation {
   pname = "odin";
@@ -39,6 +39,9 @@ in stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
+      --prefix LD_LIBRARY_PATH : $ {
+          lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL])
+        } \ 
       --set-default ODIN_ROOT $out/share
 
     runHook postInstall

--- a/odin.nix
+++ b/odin.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation {
         lib.makeBinPath (with llvmPackages; [ bintools llvm clang lld ])
       } \
       --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [ pkgs.xorg.libX11 pkgs.libGL ]
+        lib.makeLibraryPath (with pkgs; [ xorg.libX11 libGL alsa-lib ])
       } \
       --set-default ODIN_ROOT $out/share
 


### PR DESCRIPTION
Added the libraries according to https://github.com/raysan5/raylib/wiki/Working-on-GNU-Linux, at least xorg.libX11 and libGL are needed for the basic example. 

Took me forever to figure out why the basic ray lib example is not building.  

Anyway, happy to have my first contribution. 
Dnd sorry for the many commits. I am not quite aware how to import an overlay locally, so I did the edits directly on GitHub. 